### PR TITLE
Add validation to prevent publishing empty forms

### DIFF
--- a/app/components/form-builder/FormBuilder.tsx
+++ b/app/components/form-builder/FormBuilder.tsx
@@ -193,6 +193,16 @@ export function FormBuilder({ formId }: { formId: string }) {
       });
       return;
     }
+    // prevent publishing if there are no form elements
+    if (state.elements.length === 0 && !isPublished) {
+      toast({
+        title: "Error",
+        description:
+          "Cannot publish a form with no elements. Please add at least one form element.",
+        variant: "destructive",
+      });
+      return;
+    }
 
     try {
       const response = await fetch(`/api/forms/${formId}/publish`, {


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds a validation check in the `FormBuilder` component to prevent the publishing of a form if there are no elements present. It provides user feedback through a toast notification when an attempt is made to publish an empty form.

### Detailed summary
- Added a check to see if `state.elements.length` is 0 and `isPublished` is false.
- If the check fails, a toast notification is triggered with an error message.
- The function returns early to prevent further execution when no form elements are present.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->