### PR TITLE
Fix date input crashes in public forms

### DIFF
--- a/app/components/forms/elements/DateInput.tsx
+++ b/app/components/forms/elements/DateInput.tsx
@@ -57,7 +57,13 @@ export function DateInput({ element, value, onChange }: DateInputProps) {
             )}
           >
             <CalendarIcon className="mr-2 h-4 w-4" />
-            {value ? format(value, element.properties.format) : "Pick a date"}
+            {value ? (() => {
+              try {
+                return format(value, element.properties.format);
+              } catch {
+                return format(value, "PPP"); // Fallback to a safe format
+              }
+            })() : "Pick a date"}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">
@@ -75,7 +81,13 @@ export function DateInput({ element, value, onChange }: DateInputProps) {
         <input
           type="time"
           className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50"
-          value={value ? format(value, "HH:mm") : ""}
+          value={value ? (() => {
+            try {
+              return format(value, "HH:mm");
+            } catch {
+              return "";
+            }
+          })() : ""}
           onChange={(e) => {
             if (value) {
               const [hours, minutes] = e.target.value.split(":").map(Number);

--- a/app/components/forms/elements/index.tsx
+++ b/app/components/forms/elements/index.tsx
@@ -133,14 +133,29 @@ export function FormElement({
           onChange={onChange}
         />
       );
-    case FormElementType.DATE:
+    case FormElementType.DATE: {
+      let dateValue: Date | undefined;
+      try {
+        if (value instanceof Date) {
+          dateValue = value;
+        } else if (value && typeof value === 'string') {
+          const parsed = new Date(value);
+          dateValue = isNaN(parsed.getTime()) ? undefined : parsed;
+        } else {
+          dateValue = undefined;
+        }
+      } catch {
+        dateValue = undefined;
+      }
+      
       return (
         <DateInput
           element={element}
-          value={value as Date}
+          value={dateValue}
           onChange={onChange}
         />
       );
+    }
     case FormElementType.FILE_UPLOAD:
       return (
         <FileUpload


### PR DESCRIPTION
## 🐛 Bug Fix: Date Input Crashing Public Forms

### Problem
Users were experiencing crashes when selecting dates in published forms. The app would throw runtime errors and become unusable.

### Root Cause
The date input component had several type safety issues:
- Expected `Date` objects but sometimes received strings or `undefined`
- No error handling for invalid date parsing
- `date-fns` format function would crash on invalid dates
- Type casting was too aggressive without proper validation

### Solution
**Added robust type handling in FormElement component:**
- Safe date parsing with try-catch blocks
- Proper string-to-Date conversion with validation
- Fallback to `undefined` for invalid dates

**Enhanced DateInput component reliability:**
- Error handling around `format()` calls
- Safe fallback format (`"PPP"`) when custom format fails
- Protected time input formatting

**Key improvements:**
- ✅ Handles `undefined` initial values gracefully
- ✅ Converts database ISO strings to Date objects safely
- ✅ Provides fallback formatting for edge cases
- ✅ Prevents crashes from invalid date strings

### Testing
- [x] Date picker works with fresh forms (no initial value)
- [x] Date picker works with saved forms (string values from DB)
- [x] Time input works when includeTime is enabled
- [x] Invalid date formats don't crash the app
- [x] Form submission properly serializes dates to ISO strings