### PR TITLE
feat: redesign ElementToolbar with card-based layout

### DIFF
--- a/app/(dashboard)/layout.tsx
+++ b/app/(dashboard)/layout.tsx
@@ -10,14 +10,14 @@ export default function DashboardLayout({
   return (
     <div className="min-h-screen flex flex-col">
       <header className="border-b">
-        <div className="container mx-auto px-4 py-4 flex items-center justify-between">
+        <div className="container mx-auto py-4 flex items-center justify-between">
           <Link href="/dashboard" className="font-bold text-xl">
             <LogoIcon width={120} height={20} />
           </Link>
           <UserButton afterSignOutUrl="/" />
         </div>
       </header>
-      <main className="flex-1 container mx-auto px-4 py-6">{children}</main>
+      <main className="flex-1 container mx-auto py-6">{children}</main>
     </div>
   );
 }

--- a/app/components/form-builder/ElementToolbar.tsx
+++ b/app/components/form-builder/ElementToolbar.tsx
@@ -3,7 +3,6 @@ import { useFormContext } from "@/app/context/form-context";
 import { cn } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { FormElement } from "@/types/form";
-import { Separator } from "@/components/ui/separator";
 import { nanoid } from "nanoid";
 import { ELEMENT_GROUPS, isSpecialElement } from "./ElementConfig";
 import { getDefaultProperties } from "./form-utils";
@@ -36,14 +35,17 @@ export function ElementToolbar({ className }: { className?: string }) {
     <ScrollArea className={className}>
       <div className="p-4 space-y-6">
         {Object.entries(ELEMENT_GROUPS).map(([group, elements]) => (
-          <div key={group}>
-            <h3 className="text-sm font-semibold mb-2">{group}</h3>
+          <div key={group} className="space-y-3">
+            <h3 className="text-sm font-semibold text-foreground tracking-wide">
+              {group}
+            </h3>
+
             <Droppable droppableId={`toolbar-${group}`} isDropDisabled={true}>
               {(provided) => (
                 <div
                   ref={provided.innerRef}
                   {...provided.droppableProps}
-                  className="space-y-2"
+                  className="grid grid-cols-2 gap-2"
                 >
                   {elements.map(({ type, icon: Icon, label }, index) => (
                     <Draggable
@@ -58,13 +60,30 @@ export function ElementToolbar({ className }: { className?: string }) {
                           {...provided.dragHandleProps}
                           variant="ghost"
                           className={cn(
-                            "w-full justify-start",
-                            snapshot.isDragging && "ring-2 ring-primary"
+                            "h-auto min-h-[85px] flex flex-col items-center justify-center gap-3 p-3 rounded-md border transition-all duration-200 group relative overflow-hidden",
+                            "bg-card border-border shadow-sm hover:shadow-md",
+                            "hover:scale-[1.02] hover:-translate-y-0.5 hover:bg-accent",
+                            snapshot.isDragging &&
+                              "ring-2 ring-ring ring-offset-2 shadow-lg scale-105 bg-accent"
                           )}
                           onClick={() => createNewElement(type)}
                         >
-                          <Icon className="h-4 w-4 mr-2" />
-                          {label}
+                          {/* Subtle overlay on hover */}
+                          <div className="absolute inset-0 bg-gradient-to-br from-primary/5 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200" />
+
+                          {/* Icon with background circle */}
+                          <div
+                            className={cn(
+                              "w-9 h-9 rounded-full flex items-center justify-center transition-all duration-200",
+                              "bg-primary/10 group-hover:bg-primary/15 group-hover:scale-110"
+                            )}
+                          >
+                            <Icon className="h-4 w-4 flex-shrink-0 text-primary transition-all duration-200 group-hover:text-primary/80" />
+                          </div>
+
+                          <span className="text-xs font-medium text-muted-foreground text-center leading-tight px-1 relative z-10 group-hover:text-foreground transition-colors duration-200">
+                            {label}
+                          </span>
                         </Button>
                       )}
                     </Draggable>
@@ -73,7 +92,6 @@ export function ElementToolbar({ className }: { className?: string }) {
                 </div>
               )}
             </Droppable>
-            <Separator className="mt-4" />
           </div>
         ))}
       </div>

--- a/app/components/form-builder/FormBuilder.tsx
+++ b/app/components/form-builder/FormBuilder.tsx
@@ -396,7 +396,7 @@ export function FormBuilder({ formId }: { formId: string }) {
         </div>
 
         <div className="flex flex-1 overflow-hidden">
-          <ElementToolbar className="w-64 border-r" />
+          <ElementToolbar className="w-72 border-r" />
           <Canvas className="flex-1" />
           {state.activeElementId && <Properties className="w-80 border-l" />}
         </div>


### PR DESCRIPTION
Replace the vertical list layout with a modern card-based grid design that matches the UI mockup. Elements now display in a 2-column card-based grid.

- Switch from vertical list to 2-column grid layout
- Add card-style buttons with proper hover states and borders
- Implement flexible height (min-h-[80px]) for variable text lengths

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on enhancing the layout and styling of the `FormBuilder` and `ElementToolbar` components, improving responsiveness and visual appeal.

### Detailed summary
- Increased width of `ElementToolbar` from `w-64` to `w-72`.
- Removed `px-4` padding from the header in `layout.tsx`.
- Adjusted `main` element by removing `px-4`.
- Updated `ElementToolbar` to use a grid layout and improved hover effects on draggable items.
- Enhanced styling for group headers and item buttons in `ElementToolbar`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->