### PR TITLE
Auto-unpublish form when edits are made

### DIFF
--- a/app/components/form-builder/FormBuilder.tsx
+++ b/app/components/form-builder/FormBuilder.tsx
@@ -11,7 +11,7 @@ import {
   UpdateFormData,
 } from "@/types/form";
 import { useToast } from "@/hooks/use-toast";
-import { Globe, EyeOff } from "lucide-react";
+import { Globe, EyeOff, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { getDefaultProperties } from "./form-utils";
 import { FormPreview } from "./FormPreview";
@@ -32,6 +32,7 @@ export function FormBuilder({ formId }: { formId: string }) {
   const { state, dispatch } = useFormContext();
   const [isLoading, setIsLoading] = useState(true);
   const [isPublished, setIsPublished] = useState(false);
+  const [isUnpublshing, setIsUnpublishing] = useState(false);
   const [formData, setFormData] = useState<Form | null>(null);
   const { toast } = useToast();
   const { user } = useUser();
@@ -103,7 +104,46 @@ export function FormBuilder({ formId }: { formId: string }) {
   useEffect(() => {
     loadFormData();
   }, [formId]);
+  // Helper function to unpublish a form
+  const unpublishForm = async () => {
+    try {
+      setIsUnpublishing(true);
+      const response = await fetch(`/api/forms/${formId}/publish`, {
+        method: "PATCH",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          isPublished: false,
+          elements: state.elements,
+          title: state.title,
+          description: state.description,
+          settings: state.settings,
+        }),
+      });
 
+      if (!response.ok) {
+        throw new Error("Failed to unpublish form");
+      }
+
+      setIsPublished(false);
+
+      toast({
+        title: "Form Unpublished",
+        description: "Your form is now private",
+      });
+      setIsUnpublishing(false);
+      return true;
+    } catch (error) {
+      console.error("Error unpublishing form:", error);
+      toast({
+        title: "Error",
+        description: "Failed to unpublish form",
+        variant: "destructive",
+      });
+      return false;
+    }
+  };
   const saveFormChanges = async (formData: Partial<UpdateFormData>) => {
     if (formId === "new") return;
 
@@ -224,7 +264,10 @@ export function FormBuilder({ formId }: { formId: string }) {
 
       const updatedForm = await response.json();
       setIsPublished(updatedForm.isPublished);
-
+      dispatch({
+        type: "MARK_CLEAN",
+        payload: false,
+      });
       toast({
         title: updatedForm.isPublished ? "Form Published" : "Form Unpublished",
         description: updatedForm.isPublished
@@ -239,10 +282,14 @@ export function FormBuilder({ formId }: { formId: string }) {
       });
     }
   };
+  useEffect(() => {
+    if (isPublished && state.isDirty) {
+      unpublishForm();
+    }
+  }, [isPublished, state.isDirty, formId]);
 
   const handleFormUpdate = async (updates: Partial<Form>): Promise<void> => {
     try {
-      // Make the API call
       const updatedForm = await saveFormChanges(updates);
       console.log("Form updated successfully:", updatedForm);
 
@@ -376,8 +423,14 @@ export function FormBuilder({ formId }: { formId: string }) {
                   <Button
                     onClick={togglePublish}
                     variant={isPublished ? "outline" : "default"}
+                    disabled={isUnpublshing}
                   >
-                    {isPublished ? (
+                    {isUnpublshing ? (
+                      <>
+                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                        Unpublishing
+                      </>
+                    ) : isPublished ? (
                       <>
                         <EyeOff className="w-4 h-4 mr-2" />
                         Unpublish


### PR DESCRIPTION
Introduces an isDirty flag in form context to track unsaved changes since last publish. The form is automatically unpublished if edited after being published, and the UI reflects unpublishing state with a loading indicator. Reducer actions now set isDirty appropriately, and a MARK_CLEAN action resets it after publishing.

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding functionality to unpublish forms in the `FormBuilder` component, including state management for loading and dirty states. It also introduces a loading indicator during the unpublishing process.

### Detailed summary
- Added `Loader2` icon for loading state during unpublishing.
- Introduced `isUnpublishing` state in `FormBuilder`.
- Implemented `unpublishForm` function to handle form unpublishing.
- Added `MARK_CLEAN` action in the form context to reset dirty state.
- Updated form reducer to manage `isDirty` state across actions.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->